### PR TITLE
Fix quotes in curl command for alias installation

### DIFF
--- a/.devcontainer/postCreateScript.sh
+++ b/.devcontainer/postCreateScript.sh
@@ -47,7 +47,7 @@ readonly ALIAS_SRC_URL="https://raw.githubusercontent.com/gvatsal60/Linux-Aliase
 # Install Linux aliases from external script using curl and execute immediately
 # Note: Make sure to review scripts fetched from external sources for security reasons
 if command -v curl >/dev/null 2>&1; then
-    curl -fsSL ${ALIAS_SRC_URL} | sh
+    curl -fsSL "${ALIAS_SRC_URL}" | sh
 else
     echo "Error: curl is not installed. Unable to use Linux aliases"
     exit 1


### PR DESCRIPTION
This pull request makes a minor improvement to the `.devcontainer/postCreateScript.sh` script by quoting the `ALIAS_SRC_URL` variable in the `curl` command. This change enhances the script's robustness by ensuring the URL is correctly interpreted, even if it contains spaces or special characters.